### PR TITLE
Fix Windows compatibility

### DIFF
--- a/src/flupy/cli/cli.py
+++ b/src/flupy/cli/cli.py
@@ -1,7 +1,6 @@
 import argparse
 import importlib
 import sys
-from signal import SIG_DFL, SIGPIPE, signal
 from typing import Any, Dict, Generator, List, Optional
 
 from flupy import __version__, flu, walk_dirs, walk_files
@@ -66,8 +65,6 @@ def main(argv: Optional[List[str]] = None) -> None:
     if _file:
         _ = flu(read_file(_file)).map(str.rstrip)
     else:
-        # Do not raise exception for Broken Pipe
-        signal(SIGPIPE, SIG_DFL)
         _ = flu(sys.stdin).map(str.rstrip)
 
     locals_dict = {


### PR DESCRIPTION
Fixes #33.

The `SIGPIPE` signal is not available on Windows, so its import fails on that platform.

Upon further investigation, the `SIGPIPE` signal is already handled by Python by default,
so the `signal(SIGPIPE, SIG_DFL)` call _shouldn't_ actually do anything...

Currently untested on Windows, but did test that this change does not adversely affect Linux.
Will remove draft status once tested on Windows.