### PR TITLE
`filter`: add `Callable[[T], bool]` overload

### DIFF
--- a/src/flupy/fluent.py
+++ b/src/flupy/fluent.py
@@ -475,6 +475,12 @@ class Fluent(Generic[T]):
         """
         return self.map(lambda x: getattr(x, attr))
 
+    @overload
+    def filter(self, func: Callable[[T], bool], *args: Any, **kwargs: Any) -> "Fluent[T]": ...
+
+    @overload
+    def filter(self, func: Callable[..., bool], *args: Any, **kwargs: Any) -> "Fluent[T]": ...
+    
     def filter(self, func: Callable[..., bool], *args: Any, **kwargs: Any) -> "Fluent[T]":
         """Yield elements of iterable where *func* returns truthy
 


### PR DESCRIPTION
Hello!
This allows editor to recognize the type of `x` in, e.g.,

```python3
flu([3, 7]).filter(lambda x: x > 5)
```

Let me know if there's anything else you'd like me to do. Thanks!

