### PR TITLE
Fully outer join support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ venv/*
 
 # Eclipse
 .settings
+
+# LLMs
+CLAUDE.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       language_version: python3.9
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.17.0
     hooks:
     -   id: mypy
         files: flupy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flupy"
-version = "1.2.2"
+version = "1.2.3"
 description = "Fluent data processing in Python - a chainable stream processing library for expressive data manipulation using method chaining"
 authors = ["Oliver Rice <oliver@oliverrice.com>"]
 license = "MIT"


### PR DESCRIPTION
join_full
```
Join the iterable with another iterable using equality between *key* applied to self and *other_key* applied to *other* to identify matching entries
        Returns all entries from both iterables. When no matching entry is found, entries are paired with None
        Note: join_full loads both *self* and *other* into memory
        >>> flu(range(4)).join_full(range(2, 6)).to_list()
        [(0, None), (1, None), (2, 2), (3, 3), (None, 4), (None, 5)]
```

Also bumps the version to 1.2.3